### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -5,6 +5,9 @@
 
 name: Continuous Integration
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: ['main']


### PR DESCRIPTION
Potential fix for [https://github.com/Adam-Robson/container/security/code-scanning/1](https://github.com/Adam-Robson/container/security/code-scanning/1)

To fix the issue, add a `permissions` block to the workflow file. This block should specify the least privileges required for the workflow to function. Since the workflow primarily involves reading repository contents and does not perform write operations, the permissions can be set to `contents: read`. This ensures the `GITHUB_TOKEN` has only the necessary access.

The `permissions` block can be added at the root level of the workflow file to apply to all jobs or within the `build` job to limit permissions specifically for that job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
